### PR TITLE
Fix Travis deploy installing ca-certificates package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: python
-python: "2.7.13"
+python: "2.7.15"
 sudo: required
 
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *(https://github.com/idealista/vips_role/pull/4) Use of pipenv and Debian Stretch base image for tests* @jnogol
 ### Fixed
 - *(https://github.com/idealista/vips_role/pull/3) Update libvips source URL* @chadwilken
+- *(https://github.com/idealista/vips_role/pull/6) Fix Travis deploy installing ca-certificates package* @jnogol
 
 ## [1.0.0](https://github.com/idealista/vips_role/tree/1.0.0)
 ### Added

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@ vips_required_libs:
   - libmagick-dev
   - liborc-0.4-0
   - liborc-0.4-dev
+  - ca-certificates
 
 vips_sources_package: "vips-{{ vips_version }}.tar.gz"
 


### PR DESCRIPTION
In prior deployments it worked because Geerlinguy's Debian Docker image had the package installed.