### PR TITLE
Update ansible loop and test syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/vips_role/tree/develop)
+### Fixed
+- *(https://github.com/idealista/vips_role/pull/8) Update ansible loop and test syntax* @tgjohnst
 
 ## [1.0.1](https://github.com/idealista/vips_role/tree/1.0.1)
 ### Changed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,9 +2,8 @@
 
 - name: VIPS | Installing dependencies
   apt:
-    pkg: "{{ item }}"
+    pkg: "{{ vips_required_libs }}"
     state: present
-  with_items: "{{ vips_required_libs }}"
 
 - name: VIPS | Check vips version
   command: vips -v
@@ -23,4 +22,4 @@
 - name: VIPS | Install libvips from sources
   include: install-sources.yml
   when:
-    - vips_force_reinstall or vips_check|failed or 'vips-' + vips_version not in vips_check.stdout
+    - vips_force_reinstall or vips_check is failed or 'vips-' + vips_version not in vips_check.stdout


### PR DESCRIPTION
### Description of the Change

Update a couple instances of ansible loop and test syntax to fix deprecation warnings pointed out in issue #7 

### Benefits

Eliminate some ansible deprecation warnings during installation

### Possible Drawbacks

None known.

### Applicable Issues

Issue #7 
